### PR TITLE
No need to be in private browsing all the time

### DIFF
--- a/xpi/cck2.config.json
+++ b/xpi/cck2.config.json
@@ -65,7 +65,7 @@
       "value": false
     },
     "browser.privatebrowsing.autostart": {
-      "value": true
+      "value": false
     },
     "browser.urlbar.trimURLs": {
       "value": false


### PR DESCRIPTION
We already have the privacy.clearOnShutdown.\* prefs turned on as
well as privacy.sanitize.sanitizeOnShutdown. That's pretty close
to PBM but it gives us non-persistent history, which is nice.
